### PR TITLE
 Gaussian negative space mode switch

### DIFF
--- a/bundle_info.xml
+++ b/bundle_info.xml
@@ -6,7 +6,7 @@ will be displayed without the ChimeraX- prefix.
 -->
 
 <BundleInfo name="DiffFit"
-	    version="0.5.1" package="chimerax.difffit"
+	    version="0.6.0" package="chimerax.difffit"
   	    minSessionVersion="1" maxSessionVersion="1">
 
   <!-- Additional information about bundle source -->

--- a/src/DiffAtomComp.py
+++ b/src/DiffAtomComp.py
@@ -887,6 +887,7 @@ def diff_atom_comp(target_vol_path: str,
                    structures_dir: str,
                    structures_sim_map_dir: str,
                    fit_atom_mode:str = "Backbone",
+                   Gaussian_mode:str = "Gaussian with negative (shrink)",
                    N_shifts: int = 10,
                    N_quaternions: int = 100,
                    negative_space_value: float = -0.5,
@@ -937,7 +938,7 @@ def diff_atom_comp(target_vol_path: str,
         raise ValueError("Length of conv_weights does not match conv_loops! ")
 
     target_gaussian_conv_list = conv_volume(target_no_negative, device, conv_loops, conv_kernel_sizes,
-                                            negative_space_value, kernel_type="Gaussian")
+                                            negative_space_value, kernel_type="Gaussian", mode=Gaussian_mode)
 
     atom_coords_list = read_all_files_to_atom_coords_list(structures_dir, fit_atom_mode)  # atom coords as [x, y, z]
     num_molecules = len(atom_coords_list)

--- a/src/DiffAtomComp.py
+++ b/src/DiffAtomComp.py
@@ -583,10 +583,12 @@ def conv_volume(volume, device, conv_loops, kernel_sizes,
 
         volume_pad = F.pad(volume_conv_list[conv_idx - 1], filter_padding, mode="reflect")
         volume_conv = F.conv3d(volume_pad, filter)
+        volume_conv_list[conv_idx] = volume_conv
 
+    for conv_idx in range(1, conv_loops + 1):
+        volume_conv = volume_conv_list[conv_idx]
         eligible_volume_tensor = volume_conv > 0.0
         volume_conv[~eligible_volume_tensor] = negative_space_value
-
         volume_conv_list[conv_idx] = volume_conv
 
     return volume_conv_list

--- a/src/tool.py
+++ b/src/tool.py
@@ -826,6 +826,15 @@ class DiffFitTool(ToolInstance):
         row.addWidget(self._Gaussian_mode_box)
         row.addStretch()
 
+
+        row = QHBoxLayout()
+        layout.addLayout(row)
+
+        doc_label = QLabel("If the map's resolution < 5.0, we suggest using \"Gaussian with negative (shrink)\".\n"
+                           "Otherwise, we suggest using \"Gaussian then negative (expand)\".\n")
+        doc_label.setWordWrap(True)
+        row.addWidget(doc_label)
+
         layout.addStretch()
 
 

--- a/src/tool.py
+++ b/src/tool.py
@@ -793,12 +793,14 @@ class DiffFitTool(ToolInstance):
         row.addWidget(self._device)
         row.addStretch()
 
+
         row = QHBoxLayout()
         layout.addLayout(row)
 
         self._device_info_label = QLabel()
         self._device_info_label.setWordWrap(True)
         row.addWidget(self._device_info_label)
+
 
         row = QHBoxLayout()
         layout.addLayout(row)
@@ -809,6 +811,18 @@ class DiffFitTool(ToolInstance):
         self._fit_atoms.currentIndexChanged.connect(lambda: self._fit_atoms_changed())
         row.addWidget(fit_atoms_label)
         row.addWidget(self._fit_atoms)
+        row.addStretch()
+
+
+        row = QHBoxLayout()
+        layout.addLayout(row)
+
+        Gaussian_mode_label = QLabel("Gaussian mode:")
+        self._Gaussian_mode = QComboBox()
+        self._Gaussian_mode.addItems(["Gaussian with negative (shrink)", "Gaussian then negative (expand)"])
+        # self._Gaussian_mode.currentIndexChanged.connect(lambda: self._fit_atoms_changed())
+        row.addWidget(Gaussian_mode_label)
+        row.addWidget(self._Gaussian_mode)
         row.addStretch()
 
         layout.addStretch()

--- a/src/tool.py
+++ b/src/tool.py
@@ -1292,7 +1292,8 @@ class DiffFitTool(ToolInstance):
                                            smooth_loops,
                                            ast.literal_eval(self.smooth_kernel_sizes.text()),
                                            negative_space_value=negative_space_value,
-                                           kernel_type="Gaussian")
+                                           kernel_type="Gaussian",
+                                           mode=self.Gaussian_mode)
             volume_conv_list = [v.squeeze().detach().cpu().numpy() for v in volume_conv_list]
         elif smooth_by == "ChimeraX incremental Gaussian":
             for conv_idx in range(1, smooth_loops + 1):
@@ -1485,6 +1486,7 @@ class DiffFitTool(ToolInstance):
             structures_dir=self.settings.structures_directory,
             structures_sim_map_dir=self.settings.structures_sim_map_dir,
             fit_atom_mode=self.fit_atom_mode,
+            Gaussian_mode=self.Gaussian_mode,
             N_shifts=self.settings.N_shifts,
             N_quaternions=self.settings.N_quaternions,
             negative_space_value=self.settings.negative_space_value,

--- a/src/tool.py
+++ b/src/tool.py
@@ -174,6 +174,7 @@ class DiffFitTool(ToolInstance):
 
         self.fit_input_mode = "disk file"
         self.fit_atom_mode = "Backbone"
+        self.Gaussian_mode = "Gaussian with negative (shrink)"
 
         self.interactive_fit_result_ready = False
         self.fit_result = None
@@ -818,11 +819,11 @@ class DiffFitTool(ToolInstance):
         layout.addLayout(row)
 
         Gaussian_mode_label = QLabel("Gaussian mode:")
-        self._Gaussian_mode = QComboBox()
-        self._Gaussian_mode.addItems(["Gaussian with negative (shrink)", "Gaussian then negative (expand)"])
-        # self._Gaussian_mode.currentIndexChanged.connect(lambda: self._fit_atoms_changed())
+        self._Gaussian_mode_box = QComboBox()
+        self._Gaussian_mode_box.addItems(["Gaussian with negative (shrink)", "Gaussian then negative (expand)"])
+        self._Gaussian_mode_box.currentIndexChanged.connect(lambda: self._Gaussian_mode_changed())
         row.addWidget(Gaussian_mode_label)
-        row.addWidget(self._Gaussian_mode)
+        row.addWidget(self._Gaussian_mode_box)
         row.addStretch()
 
         layout.addStretch()
@@ -1110,6 +1111,10 @@ class DiffFitTool(ToolInstance):
             self.fit_atom_mode = "Backbone"
         elif self._fit_atoms.currentText() == "All atoms":
             self.fit_atom_mode = "All"
+
+
+    def _Gaussian_mode_changed(self):
+        self.Gaussian_mode = self._Gaussian_mode_box.currentText()
 
 
     def _view_input_mode_changed(self):


### PR DESCRIPTION
In the Utilities tab, added a switch to allow the users to choose between the following two modes. G0-3 is shown for 8SMK's map EMD-40589. 

### Gaussian with negative (shrink)
No negative space is added for G0 when applying Gaussian smooth. 
Starting from G1 and all the following G-layers, add the negative space (-0.5) first and then smooth it. 

![image](https://github.com/user-attachments/assets/faaee0dc-727f-46e1-b9fa-9bef093b6ec6)



### Gaussian then negative (expand)
No negative space is added for any G-layers when applying Gaussian smooth. 

![image](https://github.com/user-attachments/assets/72a9bd96-a398-4c8c-80f2-4c5778905bb7)

